### PR TITLE
Fix activation

### DIFF
--- a/zap_dev/pubspec.yaml
+++ b/zap_dev/pubspec.yaml
@@ -35,3 +35,6 @@ dev_dependencies:
 dependency_overrides:
   zap:
     path: ../zap
+
+executables:
+  zap_dev:


### PR DESCRIPTION
Fix zap_dev to support installation using dart pub global activate zap_dev command.

Just added two lines in pubspec.yaml