### PR TITLE
fix(zap_dev): Wrap interpolated identifiers in braces

### DIFF
--- a/zap/test/generated/blocks/interpolation.zap
+++ b/zap/test/generated/blocks/interpolation.zap
@@ -1,0 +1,10 @@
+<script>
+    @prop
+    String? val;
+
+    String interpolated = '';
+
+    $: interpolated = 'interpolated=$val, wrapped=${val}, isNull=${val == null}';
+</script>
+
+{interpolated}

--- a/zap/test/generated/blocks/interpolation_test.dart
+++ b/zap/test/generated/blocks/interpolation_test.dart
@@ -1,0 +1,24 @@
+@Tags(['browser'])
+import 'dart:html';
+
+import 'package:test/test.dart';
+import 'package:zap/zap.dart';
+
+import 'interpolation.zap.dart';
+
+void main() {
+  test('string interpolation', () async {
+    final testbed = Element.div();
+    final component = Interpolation(ZapValue('test'))..create(testbed);
+
+    expect(testbed.text, 'interpolated=test, wrapped=test, isNull=false');
+
+    component.val = 'updated';
+    await component.tick;
+    expect(testbed.text, 'interpolated=updated, wrapped=updated, isNull=false');
+
+    component.val = null;
+    await component.tick;
+    expect(testbed.text, 'interpolated=null, wrapped=null, isNull=true');
+  });
+}

--- a/zap_dev/lib/src/generator/generator.dart
+++ b/zap_dev/lib/src/generator/generator.dart
@@ -1682,17 +1682,14 @@ class _DartSourceRewriter extends GeneralizingAstVisitor<void> {
 
   @override
   void visitInterpolationElement(InterpolationElement node) {
-    if (node is InterpolationExpression) {
-      final expression = node.expression;
-      if (expression is SimpleIdentifier) {
-        // Interpolated variables must be wrapped in braces since the
-        // replacement identifier will have `$` in the name.
-        //
-        // For example, '$localVariable' becomes '${_$v1 /* localVariable */}'.
-        final missingBraces = node.rightBracket == null;
-        return _patchIdentifier(expression, expression.staticElement,
-            wrapVariablesInBraces: missingBraces);
-      }
+    if (node case InterpolationExpression(:final SimpleIdentifier expression)) {
+      // Interpolated variables must be wrapped in braces since the
+      // replacement identifier will have `$` in the name.
+      //
+      // For example, '$localVariable' becomes '${_$v1 /* localVariable */}'.
+      final missingBraces = node.rightBracket == null;
+      return _patchIdentifier(expression, expression.staticElement,
+          wrapVariablesInBraces: missingBraces);
     }
     super.visitInterpolationElement(node);
   }

--- a/zap_dev/lib/src/utils/base32.dart
+++ b/zap_dev/lib/src/utils/base32.dart
@@ -83,7 +83,7 @@ class _ZBase32EncodingSink extends ByteConversionSinkBase {
   }
 }
 
-class _SinkOfStringToSinkString extends StringSink {
+class _SinkOfStringToSinkString implements StringSink {
   final Sink<String> _sink;
 
   _SinkOfStringToSinkString(this._sink);

--- a/zap_dev/pubspec.yaml
+++ b/zap_dev/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.2.3+2
 homepage: https://simonbinder.eu/zap/
 
 environment:
-  sdk: '>=2.15.0 <4.0.0'
+  sdk: ^3.0.0
 
 dependencies:
   analyzer: ^6.2.0


### PR DESCRIPTION
When component variables are interpolated in strings, the replacement identifier can cause invalidate Dart code to be generated if the identifier is not wrapped in braces already.

For example:

```html
<script>
  String? value;
  String? interpolated;

  $: interpolated = '$value';
</script>
```

Here, the interpolated string currently becomes something like `$_$v2 /* value */` which is invalid Dart code, when we really want `${_$v2 /* value */}`.