### PR TITLE
chore(repo): Bump SDK constraint to Dart 3

### DIFF
--- a/docs/pubspec.yaml
+++ b/docs/pubspec.yaml
@@ -2,7 +2,7 @@ name: zap_docs
 publish_to: none
 
 environment:
-  sdk: ^2.16.0
+  sdk: ^3.0.0
 
 dependencies:
   js: ^0.6.4

--- a/material_zap/example/pubspec.yaml
+++ b/material_zap/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Port of material web components to zap
 publish_to: none
 
 environment:
-  sdk: '>=2.16.0 <3.0.0'
+  sdk: ^3.0.0
 
 dependencies:
   zap:

--- a/material_zap/pubspec.yaml
+++ b/material_zap/pubspec.yaml
@@ -3,7 +3,7 @@ description: Port of material web components to zap
 publish_to: none
 
 environment:
-  sdk: '>=2.16.0 <3.0.0'
+  sdk: ^3.0.0
 
 dependencies:
   zap:

--- a/riverpod_zap/example/pubspec.yaml
+++ b/riverpod_zap/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demo of using riverpod and zap for a simple todo app.
 publish_to: none
 
 environment:
-  sdk: '>=2.15.1 <3.0.0'
+  sdk: ^3.0.0
 
 dependencies:
   riverpod: ^2.0.0-0

--- a/riverpod_zap/pubspec.yaml
+++ b/riverpod_zap/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.2
 homepage: https://simonbinder.eu/zap/
 
 environment:
-  sdk: '>=2.15.1 <3.0.0'
+  sdk: ^3.0.0
 
 dependencies:
   riverpod: ^2.0.0

--- a/tools/pubspec.yaml
+++ b/tools/pubspec.yaml
@@ -2,7 +2,7 @@ name: tools
 publish_to: none
 
 environment:
-  sdk: '^2.16.0'
+  sdk: ^3.0.0
 
 dependencies:
   simons_pub_uploader:

--- a/zap/lib/src/dom/dom.dart
+++ b/zap/lib/src/dom/dom.dart
@@ -77,7 +77,7 @@ extension ZapDomEvents<T extends Event> on Stream<T> {
   }
 }
 
-class _ModifierSink<T extends Event> extends EventSink<T> {
+class _ModifierSink<T extends Event> implements EventSink<T> {
   final EventSink<T> _downstream;
 
   final bool preventDefault;

--- a/zap/pubspec.yaml
+++ b/zap/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.2.1
 homepage: https://simonbinder.eu/zap/
 
 environment:
-  sdk: '>=2.15.0 <4.0.0'
+  sdk: ^3.0.0
 
 dependencies:
   js: ^0.6.3

--- a/zap_dev/lib/src/utils/base32.dart
+++ b/zap_dev/lib/src/utils/base32.dart
@@ -83,7 +83,7 @@ class _ZBase32EncodingSink extends ByteConversionSinkBase {
   }
 }
 
-class _SinkOfStringToSinkString extends StringSink {
+class _SinkOfStringToSinkString implements StringSink {
   final Sink<String> _sink;
 
   _SinkOfStringToSinkString(this._sink);

--- a/zap_dev/pubspec.yaml
+++ b/zap_dev/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.2.3+2
 homepage: https://simonbinder.eu/zap/
 
 environment:
-  sdk: '>=2.15.0 <4.0.0'
+  sdk: ^3.0.0
 
 dependencies:
   analyzer: ^6.2.0


### PR DESCRIPTION
Bumps SDK constraints to `^3.0.0` to take advantage of Dart 3 features.